### PR TITLE
Merge with upstream (fix build errors with libavcodec version 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # This config file for Travis CI utilizes ros-industrial/industrial_ci package.
 # For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
 
-dist: xenial
+dist: trusty
+sudo: required
 services:
   - docker
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,28 @@
-language:
-  - cpp
-  - python
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+
+dist: xenial
+services:
+  - docker
+language: generic
 python:
   - "2.7"
 compiler:
   - gcc
+
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="kinetic"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
+
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
 
 branches:
   only:
@@ -12,20 +30,7 @@ branches:
     - develop
 
 install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install python-catkin-pkg python-rosdep ros-hydro-catkin ros-hydro-catkin -qq
-  - sudo rosdep init
-  - rosdep update
-  - mkdir -p /tmp/ws/src
-  - ln -s `pwd` /tmp/ws/src/package
-  - cd /tmp/ws/src
-  - git clone https://github.com/WPI-RAIL/async_web_server_cpp.git
-  - cd /tmp/ws
-  - rosdep install --from-paths src --ignore-src --rosdistro hydro -y
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 
 script:
-  - source /opt/ros/hydro/setup.bash
-  - catkin_make
-  - catkin_make install
+  - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@ notifications:
 env:
   matrix:
     - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
+    - ROS_DISTRO="indigo"    ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  USE_DEB=true
     - ROS_DISTRO="kinetic"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
+    - ROS_DISTRO="indigo"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
 
 matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
+    - env: ROS_DISTRO="indigo"   PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=0
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install python-catkin-pkg python-rosdep ros-groovy-catkin ros-hydro-catkin -qq
+  - sudo apt-get install python-catkin-pkg python-rosdep ros-hydro-catkin ros-hydro-catkin -qq
   - sudo rosdep init
   - rosdep update
   - mkdir -p /tmp/ws/src
   - ln -s `pwd` /tmp/ws/src/package
+  - cd /tmp/ws/src
+  - git clone https://github.com/WPI-RAIL/async_web_server_cpp.git
   - cd /tmp/ws
   - rosdep install --from-paths src --ignore-src --rosdistro hydro -y
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add "default_stream_type" parameter (`#84 <https://github.com/RobotWebTools/web_video_server/issues/84>`_)
+  This allows users to specify default stream type in their .launch files. Using a "ros_compressed" stream type sometimes
+  results in a much lower resource consumption, and having it set as a default is much nicer for end users.
+* Add a workaround for MultipartStream constant busy state (`#83 <https://github.com/RobotWebTools/web_video_server/issues/83>`_)
+  * Add a workaround for MultipartStream constant busy state
+  * Remove C++11 features
+* lax rule for topic name (`#77 <https://github.com/RobotWebTools/web_video_server/issues/77>`_)
+* Add PngStreamer (`#74 <https://github.com/RobotWebTools/web_video_server/issues/74>`_)
+* fix SteadyTimer check for backported ROS versions (`#71 <https://github.com/RobotWebTools/web_video_server/issues/71>`_)
+  i.e. on current kinetic
+* Pkg format 2 (`#68 <https://github.com/RobotWebTools/web_video_server/issues/68>`_)
+  * use package format 2
+  * add missing dependency on sensor_msgs
+* fixed undeclared CODEC_FLAG_GLOBAL_HEADER (`#65 <https://github.com/RobotWebTools/web_video_server/issues/65>`_)
+* Contributors: Andreas Klintberg, Dirk Thomas, Felix Ruess, Kazuto Murase, Viktor Kunovski, sfalexrog
+
 0.1.0 (2018-07-01)
 ------------------
 * Avoid queuing of images on slow ethernet connection (`#64 <https://github.com/RobotWebTools/web_video_server/issues/64>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge pull request `#23 <https://github.com/RobotWebTools/web_video_server/issues/23>`_ from iki-wgt/develop
+  More information when server creation is failed
+* Removed empty line
+* More detailed exception message
+  Programm behavior is not changed since the exception is rethrown.
+* Contributors: BennyRe, Russell Toris
+
 0.0.4 (2015-08-18)
 ------------------
 * Merge pull request #16 from mitchellwills/compressed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.0 (2019-01-30)
+------------------
 * Add "default_stream_type" parameter (`#84 <https://github.com/RobotWebTools/web_video_server/issues/84>`_)
   This allows users to specify default stream type in their .launch files. Using a "ros_compressed" stream type sometimes
   results in a much lower resource consumption, and having it set as a default is much nicer for end users.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.0.6 (2017-01-17)
+------------------
 * Fixed topic list to display all image topics, fixing Issue `#18 <https://github.com/RobotWebTools/web_video_server/issues/18>`_.
 * Contributors: Eric
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2018-07-01)
+------------------
 * Avoid queuing of images on slow ethernet connection (`#64 <https://github.com/RobotWebTools/web_video_server/issues/64>`_)
 * use SteadyTimer (if available) for cleaning up inactive streams (`#63 <https://github.com/RobotWebTools/web_video_server/issues/63>`_)
   * use SteadyTimer for cleaning up inactive streams

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.0.3 (2015-05-07)
+------------------
+* added verbose flag
+* Contributors: Russell Toris
+
 0.0.2 (2015-02-20)
 ------------------
 * Merge pull request #10 from mitchellwills/develop

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.0.5 (2016-10-13)
+------------------
 * Merge pull request `#23 <https://github.com/RobotWebTools/web_video_server/issues/23>`_ from iki-wgt/develop
   More information when server creation is failed
 * Removed empty line

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,33 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Avoid queuing of images on slow ethernet connection (`#64 <https://github.com/RobotWebTools/web_video_server/issues/64>`_)
+* use SteadyTimer (if available) for cleaning up inactive streams (`#63 <https://github.com/RobotWebTools/web_video_server/issues/63>`_)
+  * use SteadyTimer for cleaning up inactive streams
+  so that cleanup works correctly even if system time changes
+  SteadyTimer is available since roscpp 1.13.1
+  * possibility to use SteadyTimer on older ROS versions
+  when SteadyTimer has been backported to those...
+* Fix segfault in libav_streamer destructor (resolves `#59 <https://github.com/RobotWebTools/web_video_server/issues/59>`_) (`#60 <https://github.com/RobotWebTools/web_video_server/issues/60>`_)
+* Fix vp8 in kinetic add vp9 and h264 support (`#52 <https://github.com/RobotWebTools/web_video_server/issues/52>`_)
+  * fix vp8 in kinetic
+  * add h264 and vp9 support
+* Add Indigo test matrix in travis configuration (`#50 <https://github.com/RobotWebTools/web_video_server/issues/50>`_)
+* Set image streamer as inactive if topic is not available (`#53 <https://github.com/RobotWebTools/web_video_server/issues/53>`_)
+  * Resolves `#38 <https://github.com/RobotWebTools/web_video_server/issues/38>`_
+* Fix Build for ubuntu 14.04 (`#48 <https://github.com/RobotWebTools/web_video_server/issues/48>`_)
+  * fix issue `#47 <https://github.com/RobotWebTools/web_video_server/issues/47>`_
+  * fix double free
+* Revert "use SteadyTimer for cleaning up inactive streams (`#45 <https://github.com/RobotWebTools/web_video_server/issues/45>`_)" (`#51 <https://github.com/RobotWebTools/web_video_server/issues/51>`_)
+  This reverts commit ae74f19ada22f288a7c7a99ada7a1b9b6037c7ce.
+* use SteadyTimer for cleaning up inactive streams (`#45 <https://github.com/RobotWebTools/web_video_server/issues/45>`_)
+  so that cleanup works correctly even if system time changes
+* Use trusty instead of xenial.  See `travis-ci/travis-ci#7260 <https://github.com/travis-ci/travis-ci/issues/7260>`_ (`#49 <https://github.com/RobotWebTools/web_video_server/issues/49>`_)
+  * Also see `RobotWebTools/rosbridge_suite#311 <https://github.com/RobotWebTools/rosbridge_suite/issues/311>`_
+* Contributors: Felix Ruess, James Bailey, Jihoon Lee, randoms, schallerr
+
 0.0.7 (2017-11-20)
 ------------------
 * Ffmpeg 3 (`#43 <https://github.com/RobotWebTools/web_video_server/issues/43>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.0.4 (2015-08-18)
+------------------
+* Merge pull request #16 from mitchellwills/compressed
+  Adds support for streaming ROS compressed image topics without the need to reencode them
+* Switch to checkout async_web_server_cpp from source
+* Upgrade for change in signature of async_web_server_cpp request handler
+* Added ros compressed video streamer type
+  This directly passes the ros compressed frame data to the http socket without reencoding it
+* Switched from passing image transport to passing node handle to streamer constructors
+* Added default transport parameter for regular image streamers
+* Contributors: Mitchell Wills, Russell Toris
+
 0.0.3 (2015-05-07)
 ------------------
 * added verbose flag

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.0.7 (2017-11-20)
+------------------
 * Ffmpeg 3 (`#43 <https://github.com/RobotWebTools/web_video_server/issues/43>`_)
   * Correct use of deprecated parameters
   codec_context\_->rc_buffer_aggressivity marked as "currently useless", so removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fixed topic list to display all image topics, fixing Issue `#18 <https://github.com/RobotWebTools/web_video_server/issues/18>`_.
+* Contributors: Eric
+
 0.0.5 (2016-10-13)
 ------------------
 * Merge pull request `#23 <https://github.com/RobotWebTools/web_video_server/issues/23>`_ from iki-wgt/develop

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Ffmpeg 3 (`#43 <https://github.com/RobotWebTools/web_video_server/issues/43>`_)
+  * Correct use of deprecated parameters
+  codec_context\_->rc_buffer_aggressivity marked as "currently useless", so removed
+  codec_context\_->frame_skip_threshold access through new priv_data api
+  * New names for pixel formats
+  * AVPicture is deprecated, use AVFrame
+  * Switch to non-deprecated free functions
+  * Use new encoding api for newer versions
+  * codec_context is deprecated, use packet flags
+* Update travis configuration to test against kinetic (`#44 <https://github.com/RobotWebTools/web_video_server/issues/44>`_)
+* fixed misuse of remove_if (`#35 <https://github.com/RobotWebTools/web_video_server/issues/35>`_)
+* Merge pull request `#33 <https://github.com/RobotWebTools/web_video_server/issues/33>`_ from achim-k/patch-1
+  web_video_server: fix bool function not returning
+  This fix is required when compiling the package with `clang`. Otherwise a SIGILL (Illegal instruction) is triggered.
+* Contributors: Hans-Joachim Krauch, Jan, Jihoon Lee, russelhowe
+
 0.0.6 (2017-01-17)
 ------------------
 * Fixed topic list to display all image topics, fixing Issue `#18 <https://github.com/RobotWebTools/web_video_server/issues/18>`_.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ add_executable(${PROJECT_NAME}
   src/vp9_streamer.cpp
   src/multipart_stream.cpp
   src/ros_compressed_streamer.cpp
-  src/jpeg_streamers.cpp)
+  src/jpeg_streamers.cpp
+  src/png_streamers.cpp
+)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
   src/image_streamer.cpp
   src/libav_streamer.cpp
   src/vp8_streamer.cpp
+  src/multipart_stream.cpp
+  src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp)
 
 ## Specify libraries to link a library or executable target against

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(web_video_server)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp roslib cv_bridge image_transport async_web_server_cpp)
+find_package(catkin REQUIRED COMPONENTS roscpp roslib cv_bridge image_transport async_web_server_cpp sensor_msgs)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
   src/image_streamer.cpp
   src/libav_streamer.cpp
   src/vp8_streamer.cpp
+  src/h264_streamer.cpp
+  src/vp9_streamer.cpp
   src/multipart_stream.cpp
   src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp)

--- a/include/web_video_server/h264_streamer.h
+++ b/include/web_video_server/h264_streamer.h
@@ -1,0 +1,35 @@
+#ifndef H264_STREAMERS_H_
+#define H264_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class H264Streamer : public LibavStreamer
+{
+public:
+  H264Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~H264Streamer();
+protected:
+  virtual void initializeEncoder();
+  std::string preset_;
+};
+
+class H264StreamerType : public LibavStreamerType
+{
+public:
+  H264StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif
+

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -14,7 +14,7 @@ class ImageStreamer
 {
 public:
   ImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it);
+                ros::NodeHandle& it);
 
   void start();
 
@@ -51,7 +51,7 @@ class ImageStreamerType
 public:
   virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                                           image_transport::ImageTransport it) = 0;
+                                                           ros::NodeHandle& nh) = 0;
 
   virtual std::string create_viewer(const async_web_server_cpp::HttpRequest &request) = 0;
 };

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -13,12 +13,17 @@ namespace web_video_server
 class ImageStreamer
 {
 public:
-  ImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                ros::NodeHandle& it);
+  ImageStreamer(const async_web_server_cpp::HttpRequest &request,
+		async_web_server_cpp::HttpConnectionPtr connection,
+		ros::NodeHandle& nh);
 
-  void start();
+  virtual void start() = 0;
 
-  bool isInactive();
+  bool isInactive()
+  {
+    return inactive_;
+  }
+  ;
 
   std::string getTopic()
   {
@@ -26,15 +31,29 @@ public:
   }
   ;
 protected:
+  async_web_server_cpp::HttpConnectionPtr connection_;
+  async_web_server_cpp::HttpRequest request_;
+  ros::NodeHandle nh_;
+  bool inactive_;
+  image_transport::Subscriber image_sub_;
+  std::string topic_;
+};
+
+
+class ImageTransportImageStreamer : public ImageStreamer
+{
+public:
+  ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+			      ros::NodeHandle& nh);
+
+  virtual void start();
+
+protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time) = 0;
 
   virtual void initialize(const cv::Mat &);
 
-  async_web_server_cpp::HttpConnectionPtr connection_;
-  async_web_server_cpp::HttpRequest request_;
-  bool inactive_;
   image_transport::Subscriber image_sub_;
-  std::string topic_;
   int output_width_;
   int output_height_;
   bool invert_;

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -38,6 +38,7 @@ protected:
   int output_width_;
   int output_height_;
   bool invert_;
+  std::string default_transport_;
 private:
   image_transport::ImageTransport it_;
   bool initialized_;

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -5,11 +5,12 @@
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
 
 namespace web_video_server
 {
 
-class MjpegStreamer : public ImageStreamer
+class MjpegStreamer : public ImageTransportImageStreamer
 {
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
@@ -19,6 +20,7 @@ protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
 private:
+  MultipartStream stream_;
   int quality_;
 };
 
@@ -28,11 +30,10 @@ public:
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
                                                    ros::NodeHandle& nh);
-
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 };
 
-class JpegSnapshotStreamer : public ImageStreamer
+class JpegSnapshotStreamer : public ImageTransportImageStreamer
 {
 public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -13,7 +13,7 @@ class MjpegStreamer : public ImageStreamer
 {
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it);
+                ros::NodeHandle& nh);
 
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
@@ -27,7 +27,7 @@ class MjpegStreamerType : public ImageStreamerType
 public:
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
-                                                   image_transport::ImageTransport it);
+                                                   ros::NodeHandle& nh);
 
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 };
@@ -36,7 +36,7 @@ class JpegSnapshotStreamer : public ImageStreamer
 {
 public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
-                       async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it);
+                       async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
 
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -20,7 +20,7 @@ extern "C"
 namespace web_video_server
 {
 
-class LibavStreamer : public ImageStreamer
+class LibavStreamer : public ImageTransportImageStreamer
 {
 public:
   LibavStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -24,7 +24,7 @@ class LibavStreamer : public ImageStreamer
 {
 public:
   LibavStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it, const std::string &format_name, const std::string &codec_name,
+                ros::NodeHandle& nh, const std::string &format_name, const std::string &codec_name,
                 const std::string &content_type);
 
   ~LibavStreamer();
@@ -63,7 +63,7 @@ public:
 
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
-                                                   image_transport::ImageTransport it);
+                                                   ros::NodeHandle& nh);
 
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -40,6 +40,8 @@ protected:
   AVCodecContext* codec_context_;
   AVStream* video_stream_;
 
+  AVDictionary* opt_;   // container format options
+
 private:
   AVFrame* frame_;
   struct SwsContext* sws_context_;
@@ -53,6 +55,8 @@ private:
   int qmin_;
   int qmax_;
   int gop_;
+
+  uint8_t* io_buffer_;  // custom IO buffer
 };
 
 class LibavStreamerType : public ImageStreamerType

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -15,6 +15,7 @@ extern "C"
 #include <libswscale/swscale.h>
 #include <libavutil/opt.h>
 #include <libavutil/mathematics.h>
+#include <libavutil/imgutils.h>
 }
 
 namespace web_video_server
@@ -41,8 +42,6 @@ protected:
 
 private:
   AVFrame* frame_;
-  AVPicture* picture_;
-  AVPicture* tmp_picture_;
   struct SwsContext* sws_context_;
   ros::Time first_image_timestamp_;
   boost::mutex encode_mutex_;

--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -1,0 +1,28 @@
+#ifndef MULTIPART_STREAM_H_
+#define MULTIPART_STREAM_H_
+
+#include <ros/ros.h>
+#include <async_web_server_cpp/http_connection.hpp>
+
+namespace web_video_server
+{
+
+class MultipartStream {
+public:
+  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry="boundarydonotcross");
+
+  void sendInitialHeader();
+  void sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size);
+  void sendPartFooter();
+  void sendPartAndClear(const ros::Time &time, const std::string& type, std::vector<unsigned char> &data);
+  void sendPart(const ros::Time &time, const std::string& type, const boost::asio::const_buffer &buffer,
+		async_web_server_cpp::HttpConnection::ResourcePtr resource);
+
+private:
+  async_web_server_cpp::HttpConnectionPtr connection_;
+  std::string boundry_;
+};
+
+}
+
+#endif

--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -4,12 +4,16 @@
 #include <ros/ros.h>
 #include <async_web_server_cpp/http_connection.hpp>
 
+#include <queue>
+
 namespace web_video_server
 {
 
 class MultipartStream {
 public:
-  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry="boundarydonotcross");
+  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection,
+                  const std::string& boundry="boundarydonotcross",
+                  std::size_t max_queue_size=1);
 
   void sendInitialHeader();
   void sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size);
@@ -19,8 +23,13 @@ public:
 		async_web_server_cpp::HttpConnection::ResourcePtr resource);
 
 private:
+  bool isBusy();
+
+private:
+  const std::size_t max_queue_size_;
   async_web_server_cpp::HttpConnectionPtr connection_;
   std::string boundry_;
+  std::queue<boost::weak_ptr<const void> > pending_footers_;
 };
 
 }

--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -9,6 +9,11 @@
 namespace web_video_server
 {
 
+struct PendingFooter {
+  ros::Time timestamp;
+  boost::weak_ptr<std::string> contents;
+};
+
 class MultipartStream {
 public:
   MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection,
@@ -17,7 +22,7 @@ public:
 
   void sendInitialHeader();
   void sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size);
-  void sendPartFooter();
+  void sendPartFooter(const ros::Time &time);
   void sendPartAndClear(const ros::Time &time, const std::string& type, std::vector<unsigned char> &data);
   void sendPart(const ros::Time &time, const std::string& type, const boost::asio::const_buffer &buffer,
 		async_web_server_cpp::HttpConnection::ResourcePtr resource);
@@ -29,7 +34,7 @@ private:
   const std::size_t max_queue_size_;
   async_web_server_cpp::HttpConnectionPtr connection_;
   std::string boundry_;
-  std::queue<boost::weak_ptr<const void> > pending_footers_;
+  std::queue<PendingFooter> pending_footers_;
 };
 
 }

--- a/include/web_video_server/png_streamers.h
+++ b/include/web_video_server/png_streamers.h
@@ -1,0 +1,51 @@
+#ifndef PNG_STREAMERS_H_
+#define PNG_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/image_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
+
+namespace web_video_server
+{
+
+class PngStreamer : public ImageTransportImageStreamer
+{
+public:
+  PngStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+
+protected:
+  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+
+private:
+  MultipartStream stream_;
+  int quality_;
+};
+
+class PngStreamerType : public ImageStreamerType
+{
+public:
+  boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                   async_web_server_cpp::HttpConnectionPtr connection,
+                                                   ros::NodeHandle& nh);
+  std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
+};
+
+class PngSnapshotStreamer : public ImageTransportImageStreamer
+{
+public:
+  PngSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
+                      async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
+
+protected:
+  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+
+private:
+  int quality_;
+};
+
+}
+
+#endif

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -1,0 +1,38 @@
+#ifndef ROS_COMPRESSED_STREAMERS_H_
+#define ROS_COMPRESSED_STREAMERS_H_
+
+#include <sensor_msgs/CompressedImage.h>
+#include "web_video_server/image_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
+
+namespace web_video_server
+{
+
+class RosCompressedStreamer : public ImageStreamer
+{
+public:
+  RosCompressedStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+			ros::NodeHandle& nh);
+  virtual void start();
+
+private:
+  void imageCallback(const sensor_msgs::CompressedImageConstPtr &msg);
+
+  MultipartStream stream_;
+  ros::Subscriber image_sub_;
+};
+
+class RosCompressedStreamerType : public ImageStreamerType
+{
+public:
+  boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                   async_web_server_cpp::HttpConnectionPtr connection,
+                                                   ros::NodeHandle& nh);
+  std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
+};
+
+}
+
+#endif

--- a/include/web_video_server/vp8_streamer.h
+++ b/include/web_video_server/vp8_streamer.h
@@ -49,7 +49,7 @@ class Vp8Streamer : public LibavStreamer
 {
 public:
   Vp8Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
-              image_transport::ImageTransport it);
+              ros::NodeHandle& nh);
   ~Vp8Streamer();
 protected:
   virtual void initializeEncoder();
@@ -63,7 +63,7 @@ public:
   Vp8StreamerType();
   virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
                                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                                           image_transport::ImageTransport it);
+                                                           ros::NodeHandle& nh);
 };
 
 }

--- a/include/web_video_server/vp9_streamer.h
+++ b/include/web_video_server/vp9_streamer.h
@@ -1,0 +1,33 @@
+#ifndef VP9_STREAMERS_H_
+#define VP9_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class Vp9Streamer : public LibavStreamer
+{
+public:
+  Vp9Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~Vp9Streamer();
+protected:
+  virtual void initializeEncoder();
+};
+
+class Vp9StreamerType : public LibavStreamerType
+{
+public:
+  Vp9StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -51,7 +51,7 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-  ros::Timer cleanup_timer_;
+  ros::SteadyTimer cleanup_timer_;
   int ros_threads_;
   int port_;
   std::string address_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -2,7 +2,6 @@
 #define WEB_VIDEO_SERVER_H_
 
 #include <ros/ros.h>
-#include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 #include <vector>
 #include "web_video_server/image_streamer.h"
@@ -52,7 +51,6 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-  image_transport::ImageTransport image_transport_;
   ros::Timer cleanup_timer_;
   int ros_threads_;
   int port_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -35,16 +35,16 @@ public:
    */
   void spin();
 
-  void handle_stream(const async_web_server_cpp::HttpRequest &request,
+  bool handle_stream(const async_web_server_cpp::HttpRequest &request,
                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
+  bool handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
                             async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_snapshot(const async_web_server_cpp::HttpRequest &request,
+  bool handle_snapshot(const async_web_server_cpp::HttpRequest &request,
                        async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_list_streams(const async_web_server_cpp::HttpRequest &request,
+  bool handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
 private:

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -51,7 +51,11 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
+#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+  ros::SteadyTimer cleanup_timer_;
+#else
   ros::Timer cleanup_timer_;
+#endif
   int ros_threads_;
   int port_;
   std::string address_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -9,6 +9,8 @@
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"
 
+#define ROS_HAS_STEADYTIMER (ROS_VERSION_MINIMUM(1, 13, 1) || ((ROS_VERSION_MINOR == 12) && (ROS_VERSION_PATCH >= 8)))
+
 namespace web_video_server
 {
 
@@ -51,7 +53,7 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+#if ROS_HAS_STEADYTIMER || defined USE_STEADY_TIMER
   ros::SteadyTimer cleanup_timer_;
 #else
   ros::Timer cleanup_timer_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -51,7 +51,7 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-  ros::SteadyTimer cleanup_timer_;
+  ros::Timer cleanup_timer_;
   int ros_threads_;
   int port_;
   std::string address_;

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>web_video_server</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>web_video_server</name>
   <version>0.1.0</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
@@ -21,11 +21,13 @@
   <build_depend>image_transport</build_depend>
   <build_depend>async_web_server_cpp</build_depend>
   <build_depend>ffmpeg</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>async_web_server_cpp</run_depend>
-  <run_depend>ffmpeg</run_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>async_web_server_cpp</exec_depend>
+  <exec_depend>ffmpeg</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.4</version>
+  <version>0.0.5</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.7</version>
+  <version>0.1.0</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>web_video_server</name>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/src/h264_streamer.cpp
+++ b/src/h264_streamer.cpp
@@ -1,0 +1,49 @@
+#include "web_video_server/h264_streamer.h"
+
+namespace web_video_server
+{
+
+H264Streamer::H264Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "mp4", "libx264", "video/mp4")
+{
+  /* possible quality presets:
+   * ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow, placebo
+   * no latency improvements observed with ultrafast instead of medium
+   */
+  preset_ = request.get_query_param_value_or_default("preset", "ultrafast");
+}
+
+H264Streamer::~H264Streamer()
+{
+}
+
+void H264Streamer::initializeEncoder()
+{
+  av_opt_set(codec_context_->priv_data, "preset", preset_.c_str(), 0);
+  av_opt_set(codec_context_->priv_data, "tune", "zerolatency", 0);
+  av_opt_set_int(codec_context_->priv_data, "crf", 20, 0);
+  av_opt_set_int(codec_context_->priv_data, "bufsize", 100, 0);
+  av_opt_set_int(codec_context_->priv_data, "keyint", 30, 0);
+  av_opt_set_int(codec_context_->priv_data, "g", 1, 0);
+
+  // container format options
+  if (!strcmp(format_context_->oformat->name, "mp4")) {
+    // set up mp4 for streaming (instead of seekable file output)
+    av_dict_set(&opt_, "movflags", "+frag_keyframe+empty_moov+faststart", 0);
+  }
+}
+
+H264StreamerType::H264StreamerType() :
+    LibavStreamerType("mp4", "libx264", "video/mp4")
+{
+}
+
+boost::shared_ptr<ImageStreamer> H264StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new H264Streamer(request, connection, nh));
+}
+
+}

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -6,26 +6,32 @@ namespace web_video_server
 
 ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
-    request_(request), connection_(connection), it_(nh), inactive_(false), initialized_(false)
+    request_(request), connection_(connection), nh_(nh), inactive_(false)
 {
   topic_ = request.get_query_param_value_or_default("topic", "");
+}
+
+ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageStreamer(request, connection, nh), it_(nh), initialized_(false)
+{
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
 }
 
-void ImageStreamer::start()
+void ImageTransportImageStreamer::start()
 {
   image_transport::TransportHints hints(default_transport_);
-  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this, hints);
+  image_sub_ = it_.subscribe(topic_, 1, &ImageTransportImageStreamer::imageCallback, this, hints);
 }
 
-void ImageStreamer::initialize(const cv::Mat &)
+void ImageTransportImageStreamer::initialize(const cv::Mat &)
 {
 }
 
-void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
+void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
 {
   if (inactive_)
     return;
@@ -120,11 +126,6 @@ void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
     inactive_ = true;
     return;
   }
-}
-
-bool ImageStreamer::isInactive()
-{
-  return inactive_;
 }
 
 }

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,6 +24,14 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
 void ImageTransportImageStreamer::start()
 {
   image_transport::TransportHints hints(default_transport_);
+  ros::master::V_TopicInfo available_topics;
+  ros::master::getTopics(available_topics);
+  inactive_ = true;
+  for (size_t it = 0; it<available_topics.size(); it++){
+    if(available_topics[it].name == topic_){
+      inactive_ = false;
+    }
+  }
   image_sub_ = it_.subscribe(topic_, 1, &ImageTransportImageStreamer::imageCallback, this, hints);
 }
 

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -12,11 +12,13 @@ ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
+  default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
 }
 
 void ImageStreamer::start()
 {
-  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this);
+  image_transport::TransportHints hints(default_transport_);
+  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this, hints);
 }
 
 void ImageStreamer::initialize(const cv::Mat &)

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -28,7 +28,9 @@ void ImageTransportImageStreamer::start()
   ros::master::getTopics(available_topics);
   inactive_ = true;
   for (size_t it = 0; it<available_topics.size(); it++){
-    if(available_topics[it].name == topic_){
+    std::string available_topic_name = available_topics[it].name;
+    if(available_topic_name == topic_ || (available_topic_name.find("/") == 0 &&
+                                          available_topic_name.substr(1) == topic_)) {
       inactive_ = false;
     }
   }

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -5,8 +5,8 @@ namespace web_video_server
 {
 
 ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    request_(request), connection_(connection), it_(it), inactive_(false), initialized_(false)
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    request_(request), connection_(connection), it_(nh), inactive_(false), initialized_(false)
 {
   topic_ = request.get_query_param_value_or_default("topic", "");
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -6,16 +6,10 @@ namespace web_video_server
 
 MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
-    ImageStreamer(request, connection, nh)
+  ImageTransportImageStreamer(request, connection, nh), stream_(connection)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
-
-  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
-      "Server", "web_video_server").header("Cache-Control",
-                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
-      "Pragma", "no-cache").header("Content-type", "multipart/x-mixed-replace;boundary=--boundarydonotcross ").header(
-      "Access-Control-Allow-Origin", "*").write(connection);
-  connection->write("--boundarydonotcross \r\n");
+  stream_.sendInitialHeader();
 }
 
 void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
@@ -27,17 +21,7 @@ void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
   std::vector<uchar> encoded_buffer;
   cv::imencode(".jpeg", img, encoded_buffer, encode_params);
 
-  char stamp[20];
-  sprintf(stamp, "%.06lf", time.toSec());
-  boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
-      new std::vector<async_web_server_cpp::HttpHeader>());
-  headers->push_back(async_web_server_cpp::HttpHeader("Content-type", "image/jpeg"));
-  headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
-  headers->push_back(
-      async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(encoded_buffer.size())));
-  connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
-  connection_->write_and_clear(encoded_buffer);
-  connection_->write("\r\n--boundarydonotcross \r\n");
+  stream_.sendPartAndClear(time, "image/jpeg", encoded_buffer);
 }
 
 boost::shared_ptr<ImageStreamer> MjpegStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
@@ -59,7 +43,7 @@ std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpReq
 JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                                            async_web_server_cpp::HttpConnectionPtr connection,
                                            ros::NodeHandle& nh) :
-    ImageStreamer(request, connection, nh)
+    ImageTransportImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -5,8 +5,8 @@ namespace web_video_server
 {
 
 MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    ImageStreamer(request, connection, it)
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    ImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 
@@ -42,9 +42,9 @@ void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 
 boost::shared_ptr<ImageStreamer> MjpegStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                                     async_web_server_cpp::HttpConnectionPtr connection,
-                                                                    image_transport::ImageTransport it)
+                                                                    ros::NodeHandle& nh)
 {
-  return boost::shared_ptr<ImageStreamer>(new MjpegStreamer(request, connection, it));
+  return boost::shared_ptr<ImageStreamer>(new MjpegStreamer(request, connection, nh));
 }
 
 std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
@@ -58,8 +58,8 @@ std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpReq
 
 JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                           image_transport::ImageTransport it) :
-    ImageStreamer(request, connection, it)
+                                           ros::NodeHandle& nh) :
+    ImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -68,7 +68,7 @@ LibavStreamer::~LibavStreamer()
     avcodec_close(codec_context_);
   if (frame_)
   {
-#if (LIBAVCODEC_VERSION_MAJOR < 54)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
     av_free(frame_);
     frame_ = NULL;
 #else
@@ -163,7 +163,11 @@ void LibavStreamer::initialize(const cv::Mat &img)
   }
 
   // Allocate frame buffers
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
+  frame_ = avcodec_alloc_frame();
+#else
   frame_ = av_frame_alloc();
+#endif
   av_image_alloc(frame_->data, frame_->linesize, output_width_, output_height_,
           codec_context_->pix_fmt, 1);
 
@@ -219,14 +223,22 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
     first_image_timestamp_ = time;
   }
   std::vector<uint8_t> encoded_frame;
-#if (LIBAVUTIL_VERSION_MAJOR < 52)
+#if (LIBAVUTIL_VERSION_MAJOR < 53)
   PixelFormat input_coding_format = PIX_FMT_BGR24;
 #else
   AVPixelFormat input_coding_format = AV_PIX_FMT_BGR24;
 #endif
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
+  AVPicture *raw_frame = new AVPicture;
+  avpicture_fill(raw_frame, img.data, input_coding_format, output_width_, output_height_);
+#else
   AVFrame *raw_frame = av_frame_alloc();
   av_image_fill_arrays(raw_frame->data, raw_frame->linesize,
                        img.data, input_coding_format, output_width_, output_height_, 0);
+#endif
+
+
 
   // Convert from opencv to libav
   if (!sws_context_)
@@ -245,7 +257,11 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
           (const uint8_t * const *)raw_frame->data, raw_frame->linesize, 0,
           output_height_, frame_->data, frame_->linesize);
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
+  delete raw_frame;
+#else
   av_frame_free(&raw_frame);
+#endif
 
   // Encode the frame
   AVPacket pkt;
@@ -312,11 +328,15 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
   {
     encoded_frame.clear();
   }
-#if (LIBAVCODEC_VERSION_MAJOR < 54)
+#if LIBAVCODEC_VERSION_INT < 54
   av_free(pkt.data);
 #endif
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
+  av_free_packet(&pkt);
+#else
   av_packet_unref(&pkt);
+#endif
 
   connection_->write_and_clear(encoded_frame);
 }

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -1,6 +1,10 @@
 #include "web_video_server/libav_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
 
+/*https://stackoverflow.com/questions/46884682/error-in-building-opencv-with-ffmpeg*/
+#define AV_CODEC_FLAG_GLOBAL_HEADER (1 << 22)
+#define CODEC_FLAG_GLOBAL_HEADER AV_CODEC_FLAG_GLOBAL_HEADER
+
 namespace web_video_server
 {
 

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -48,7 +48,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh,
                              const std::string &format_name, const std::string &codec_name,
                              const std::string &content_type) :
-    ImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
+    ImageTransportImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), picture_(0), tmp_picture_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
         format_name), codec_name_(codec_name), content_type_(content_type)
 {

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -50,7 +50,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
                              const std::string &content_type) :
     ImageTransportImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
-        format_name), codec_name_(codec_name), content_type_(content_type)
+        format_name), codec_name_(codec_name), content_type_(content_type), opt_(0), io_buffer_(0)
 {
 
   bitrate_ = request.get_query_param_value_or_default<int>("bitrate", 100000);
@@ -75,10 +75,24 @@ LibavStreamer::~LibavStreamer()
     av_frame_free(&frame_);
 #endif
   }
+  if (io_buffer_)
+    delete io_buffer_;
+  if (format_context_->pb)
+    av_free(format_context_->pb);
   if (format_context_)
     avformat_free_context(format_context_);
   if (sws_context_)
     sws_freeContext(sws_context_);
+}
+
+// output callback for ffmpeg IO context
+static int dispatch_output_packet(void* opaque, uint8_t* buffer, int buffer_size)
+{
+  async_web_server_cpp::HttpConnectionPtr connection = *((async_web_server_cpp::HttpConnectionPtr*) opaque);
+  std::vector<uint8_t> encoded_frame;
+  encoded_frame.assign(buffer, buffer + buffer_size);
+  connection->write_and_clear(encoded_frame);
+  return 0; // TODO: can this fail?
 }
 
 void LibavStreamer::initialize(const cv::Mat &img)
@@ -101,6 +115,22 @@ void LibavStreamer::initialize(const cv::Mat &img)
     throw std::runtime_error("Error looking up output format");
   }
   format_context_->oformat = output_format_;
+
+  // Set up custom IO callback.
+  size_t io_buffer_size = 3 * 1024;    // 3M seen elsewhere and adjudged good
+  io_buffer_ = new unsigned char[io_buffer_size];
+  AVIOContext* io_ctx = avio_alloc_context(io_buffer_, io_buffer_size, AVIO_FLAG_WRITE, &connection_, NULL, dispatch_output_packet, NULL);
+  if (!io_ctx)
+  {
+    async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::internal_server_error)(request_,
+                                                                                                         connection_,
+                                                                                                         NULL, NULL);
+    throw std::runtime_error("Error setting up IO context");
+  }
+  io_ctx->seekable = 0;                       // no seeking, it's a stream
+  format_context_->pb = io_ctx;
+  output_format_->flags |= AVFMT_FLAG_CUSTOM_IO;
+  output_format_->flags |= AVFMT_NOFILE;
 
   // Load codec
   if (codec_name_.empty()) // use default codec if none specified
@@ -127,7 +157,7 @@ void LibavStreamer::initialize(const cv::Mat &img)
   // Set options
   avcodec_get_context_defaults3(codec_context_, codec_);
 
-  codec_context_->codec_id = output_format_->video_codec;
+  codec_context_->codec_id = codec_->id;
   codec_context_->bit_rate = bitrate_;
 
   codec_context_->width = output_width_;
@@ -171,7 +201,9 @@ void LibavStreamer::initialize(const cv::Mat &img)
   av_image_alloc(frame_->data, frame_->linesize, output_width_, output_height_,
           codec_context_->pix_fmt, 1);
 
-
+  frame_->width = output_width_;
+  frame_->height = output_height_;
+  frame_->format = codec_context_->pix_fmt;
   output_format_->flags |= AVFMT_NOFILE;
 
   // Generate header
@@ -182,24 +214,6 @@ void LibavStreamer::initialize(const cv::Mat &img)
   av_dict_set(&format_context_->metadata, "author", "ROS web_video_server", 0);
   av_dict_set(&format_context_->metadata, "title", topic_.c_str(), 0);
 
-  if (avio_open_dyn_buf(&format_context_->pb) >= 0)
-  {
-    if (avformat_write_header(format_context_, NULL) < 0)
-    {
-      async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::internal_server_error)(request_,
-                                                                                                           connection_,
-                                                                                                           NULL, NULL);
-      throw std::runtime_error("Error openning dynamic buffer");
-    }
-    header_size = avio_close_dyn_buf(format_context_->pb, &header_raw_buffer);
-
-    // copy header buffer to vector
-    header_buffer.resize(header_size);
-    memcpy(&header_buffer[0], header_raw_buffer, header_size);
-
-    av_free(header_raw_buffer);
-  }
-
   // Send response headers
   async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
       "Server", "web_video_server").header("Cache-Control",
@@ -208,7 +222,13 @@ void LibavStreamer::initialize(const cv::Mat &img)
       "Content-type", content_type_).header("Access-Control-Allow-Origin", "*").write(connection_);
 
   // Send video stream header
-  connection_->write_and_clear(header_buffer);
+  if (avformat_write_header(format_context_, &opt_) < 0)
+  {
+    async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::internal_server_error)(request_,
+                                                                                                         connection_,
+                                                                                                         NULL, NULL);
+    throw std::runtime_error("Error openning dynamic buffer");
+  }
 }
 
 void LibavStreamer::initializeEncoder()
@@ -235,7 +255,7 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 #else
   AVFrame *raw_frame = av_frame_alloc();
   av_image_fill_arrays(raw_frame->data, raw_frame->linesize,
-                       img.data, input_coding_format, output_width_, output_height_, 0);
+                       img.data, input_coding_format, output_width_, output_height_, 1);
 #endif
 
 
@@ -310,18 +330,9 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 
     pkt.stream_index = video_stream_->index;
 
-    if (avio_open_dyn_buf(&format_context_->pb) >= 0)
+    if (av_write_frame(format_context_, &pkt))
     {
-      if (av_write_frame(format_context_, &pkt))
-      {
-        throw std::runtime_error("Error when writing frame");
-      }
-      size = avio_close_dyn_buf(format_context_->pb, &output_buf);
-
-      encoded_frame.resize(size);
-      memcpy(&encoded_frame[0], output_buf, size);
-
-      av_free(output_buf);
+      throw std::runtime_error("Error when writing frame");
     }
   }
   else

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -45,10 +45,10 @@ static int ffmpeg_boost_mutex_lock_manager(void **mutex, enum AVLockOp op)
 }
 
 LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh,
                              const std::string &format_name, const std::string &codec_name,
                              const std::string &content_type) :
-    ImageStreamer(request, connection, it), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
+    ImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), picture_(0), tmp_picture_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
         format_name), codec_name_(codec_name), content_type_(content_type)
 {
@@ -331,10 +331,10 @@ LibavStreamerType::LibavStreamerType(const std::string &format_name, const std::
 
 boost::shared_ptr<ImageStreamer> LibavStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                                     async_web_server_cpp::HttpConnectionPtr connection,
-                                                                    image_transport::ImageTransport it)
+                                                                    ros::NodeHandle& nh)
 {
   return boost::shared_ptr<ImageStreamer>(
-      new LibavStreamer(request, connection, it, format_name_, codec_name_, content_type_));
+      new LibavStreamer(request, connection, nh, format_name_, codec_name_, content_type_));
 }
 
 std::string LibavStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -77,10 +77,11 @@ LibavStreamer::~LibavStreamer()
   }
   if (io_buffer_)
     delete io_buffer_;
-  if (format_context_->pb)
-    av_free(format_context_->pb);
-  if (format_context_)
+  if (format_context_) {
+    if (format_context_->pb)
+      av_free(format_context_->pb);
     avformat_free_context(format_context_);
+  }
   if (sws_context_)
     sws_freeContext(sws_context_);
 }

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -1,0 +1,51 @@
+#include "web_video_server/multipart_stream.h"
+#include "async_web_server_cpp/http_reply.hpp"
+
+namespace web_video_server
+{
+
+MultipartStream::MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry)
+  : connection_(connection), boundry_(boundry) {}
+
+void MultipartStream::sendInitialHeader() {
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
+      "Server", "web_video_server").header("Cache-Control",
+                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
+      "Pragma", "no-cache").header("Content-type", "multipart/x-mixed-replace;boundary="+boundry_).header(
+      "Access-Control-Allow-Origin", "*").write(connection_);
+  connection_->write("--"+boundry_+"\r\n");
+}
+
+void MultipartStream::sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size) {
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
+      new std::vector<async_web_server_cpp::HttpHeader>());
+  headers->push_back(async_web_server_cpp::HttpHeader("Content-type", type));
+  headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
+  headers->push_back(
+      async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(payload_size)));
+  connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
+}
+
+void MultipartStream::sendPartFooter() {
+  connection_->write("\r\n--"+boundry_+"\r\n");
+}
+
+void MultipartStream::sendPartAndClear(const ros::Time &time, const std::string& type,
+				       std::vector<unsigned char> &data) {
+  sendPartHeader(time, type, data.size());
+  connection_->write_and_clear(data);
+  sendPartFooter();
+}
+
+void MultipartStream::sendPart(const ros::Time &time, const std::string& type,
+			       const boost::asio::const_buffer &buffer,
+			       async_web_server_cpp::HttpConnection::ResourcePtr resource) {
+  sendPartHeader(time, type, boost::asio::buffer_size(buffer));
+  connection_->write(buffer, resource);
+  sendPartFooter();
+}
+
+
+}

--- a/src/png_streamers.cpp
+++ b/src/png_streamers.cpp
@@ -1,0 +1,73 @@
+#include "web_video_server/png_streamers.h"
+#include "async_web_server_cpp/http_reply.hpp"
+
+namespace web_video_server
+{
+
+PngStreamer::PngStreamer(const async_web_server_cpp::HttpRequest &request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageTransportImageStreamer(request, connection, nh), stream_(connection)
+{
+  quality_ = request.get_query_param_value_or_default<int>("quality", 3);
+  stream_.sendInitialHeader();
+}
+
+void PngStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<int> encode_params;
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(quality_);
+
+  std::vector<uchar> encoded_buffer;
+  cv::imencode(".png", img, encoded_buffer, encode_params);
+
+  stream_.sendPartAndClear(time, "image/png", encoded_buffer);
+}
+
+boost::shared_ptr<ImageStreamer> PngStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new PngStreamer(request, connection, nh));
+}
+
+std::string PngStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
+{
+  std::stringstream ss;
+  ss << "<img src=\"/stream?";
+  ss << request.query;
+  ss << "\"></img>";
+  return ss.str();
+}
+
+PngSnapshotStreamer::PngSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
+                                         async_web_server_cpp::HttpConnectionPtr connection,
+                                         ros::NodeHandle& nh) :
+    ImageTransportImageStreamer(request, connection, nh)
+{
+  quality_ = request.get_query_param_value_or_default<int>("quality", 3);
+}
+
+void PngSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<int> encode_params;
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(quality_);
+
+  std::vector<uchar> encoded_buffer;
+  cv::imencode(".png", img, encoded_buffer, encode_params);
+
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
+      "Server", "web_video_server").header("Cache-Control",
+                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
+      "X-Timestamp", stamp).header("Pragma", "no-cache").header("Content-type", "image/png").header(
+      "Access-Control-Allow-Origin", "*").header("Content-Length",
+                                                 boost::lexical_cast<std::string>(encoded_buffer.size())).write(
+      connection_);
+  connection_->write_and_clear(encoded_buffer);
+  inactive_ = true;
+}
+
+}

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -1,0 +1,73 @@
+#include "web_video_server/ros_compressed_streamer.h"
+
+namespace web_video_server
+{
+
+RosCompressedStreamer::RosCompressedStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageStreamer(request, connection, nh), stream_(connection)
+{
+  stream_.sendInitialHeader();
+}
+
+void RosCompressedStreamer::start() {
+  std::string compressed_topic = topic_ + "/compressed";
+  image_sub_ = nh_.subscribe(compressed_topic, 1, &RosCompressedStreamer::imageCallback, this);
+}
+
+void RosCompressedStreamer::imageCallback(const sensor_msgs::CompressedImageConstPtr &msg) {
+  try {
+    std::string content_type;
+    if(msg->format.find("jpeg") != std::string::npos) {
+      content_type = "image/jpeg";
+    }
+    else if(msg->format.find("png") != std::string::npos) {
+      content_type = "image/png";
+    }
+    else {
+      ROS_WARN_STREAM("Unknown ROS compressed image format: " << msg->format);
+      return;
+    }
+
+    stream_.sendPart(msg->header.stamp, content_type, boost::asio::buffer(msg->data), msg);
+  }
+  catch (boost::system::system_error &e)
+  {
+    // happens when client disconnects
+    ROS_DEBUG("system_error exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (std::exception &e)
+  {
+    ROS_ERROR_THROTTLE(30, "exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (...)
+  {
+    ROS_ERROR_THROTTLE(30, "exception");
+    inactive_ = true;
+    return;
+  }
+}
+
+
+boost::shared_ptr<ImageStreamer> RosCompressedStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
+										 async_web_server_cpp::HttpConnectionPtr connection,
+										 ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new RosCompressedStreamer(request, connection, nh));
+}
+
+std::string RosCompressedStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
+{
+  std::stringstream ss;
+  ss << "<img src=\"/stream?";
+  ss << request.query;
+  ss << "\"></img>";
+  return ss.str();
+}
+
+
+}

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -40,8 +40,8 @@ namespace web_video_server
 {
 
 Vp8Streamer::Vp8Streamer(const async_web_server_cpp::HttpRequest& request,
-                         async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    LibavStreamer(request, connection, it, "webm", "libvpx", "video/webm")
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "webm", "libvpx", "video/webm")
 {
   quality_ = request.get_query_param_value_or_default("quality", "realtime");
 }
@@ -84,9 +84,9 @@ Vp8StreamerType::Vp8StreamerType() :
 
 boost::shared_ptr<ImageStreamer> Vp8StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
                                                                   async_web_server_cpp::HttpConnectionPtr connection,
-                                                                  image_transport::ImageTransport it)
+                                                                  ros::NodeHandle& nh)
 {
-  return boost::shared_ptr<ImageStreamer>(new Vp8Streamer(request, connection, it));
+  return boost::shared_ptr<ImageStreamer>(new Vp8Streamer(request, connection, nh));
 }
 
 }

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -73,8 +73,7 @@ void Vp8Streamer::initializeEncoder()
   av_opt_set_int(codec_context_->priv_data, "bufsize", bufsize, 0);
   av_opt_set_int(codec_context_->priv_data, "buf-initial", bufsize, 0);
   av_opt_set_int(codec_context_->priv_data, "buf-optimal", bufsize, 0);
-  codec_context_->rc_buffer_aggressivity = 0.5;
-  codec_context_->frame_skip_threshold = 10;
+  av_opt_set_int(codec_context_->priv_data, "skip_threshold", 10, 0);
 }
 
 Vp8StreamerType::Vp8StreamerType() :

--- a/src/vp9_streamer.cpp
+++ b/src/vp9_streamer.cpp
@@ -1,0 +1,38 @@
+#include "web_video_server/vp9_streamer.h"
+
+namespace web_video_server
+{
+
+Vp9Streamer::Vp9Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "webm", "libvpx-vp9", "video/webm")
+{
+}
+Vp9Streamer::~Vp9Streamer()
+{
+}
+
+void Vp9Streamer::initializeEncoder()
+{
+
+  // codec options set up to provide somehow reasonable performance in cost of poor quality
+  // should be updated as soon as VP9 encoding matures
+  av_opt_set_int(codec_context_->priv_data, "pass", 1, 0);
+  av_opt_set_int(codec_context_->priv_data, "speed", 8, 0);
+  av_opt_set_int(codec_context_->priv_data, "cpu-used", 4, 0);  // 8 is max
+  av_opt_set_int(codec_context_->priv_data, "crf", 20, 0);      // 0..63 (higher is lower quality)
+}
+
+Vp9StreamerType::Vp9StreamerType() :
+    LibavStreamerType("webm", "libvpx-vp9", "video/webm")
+{
+}
+
+boost::shared_ptr<ImageStreamer> Vp9StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new Vp9Streamer(request, connection, nh));
+}
+
+}

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -234,6 +234,23 @@ bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
     }
     connection->write("</li>");
   }
+  connection->write("</ul>");
+  // Add the rest of the image topics that don't have camera_info.
+  connection->write("<ul>");
+  std::vector<std::string>::iterator image_topic_itr = image_topics.begin();
+  for (; image_topic_itr != image_topics.end();) {
+    connection->write("<li><a href=\"/stream_viewer?topic=");
+    connection->write(*image_topic_itr);
+    connection->write("\">");
+    connection->write(*image_topic_itr);
+    connection->write("</a> (");
+    connection->write("<a href=\"/snapshot?topic=");
+    connection->write(*image_topic_itr);
+    connection->write("\">Snapshot</a>)");
+    connection->write("</li>");
+
+    image_topic_itr = image_topics.erase(image_topic_itr);
+  }
   connection->write("</ul></body></html>");
   return true;
 }

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -42,7 +42,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
-  cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+  cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
 
   private_nh.param("port", port_, 8080);
   private_nh.param("verbose", __verbose, true);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -28,11 +28,14 @@ static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler
   try
   {
     forward(request, connection, begin, end);
+    return true;
   }
   catch (std::exception &e)
   {
     ROS_WARN_STREAM("Error Handling Request: " << e.what());
+    return false;
   }
+  return false;
 }
 
 WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh) :

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -16,7 +16,7 @@ namespace web_video_server
 
 static bool __verbose;
 
-static void ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler forward,
+static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler forward,
                                   const async_web_server_cpp::HttpRequest &request,
                                   async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                   const char* end)
@@ -99,7 +99,7 @@ void WebVideoServer::cleanup_inactive_streams()
   }
 }
 
-void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &request,
                                    async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                    const char* end)
 {
@@ -116,9 +116,10 @@ void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(request, connection, begin,
                                                                                              end);
   }
+  return true;
 }
 
-void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &request,
                                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                      const char* end)
 {
@@ -127,9 +128,10 @@ void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &re
 
   boost::mutex::scoped_lock lock(subscriber_mutex_);
   image_subscribers_.push_back(streamer);
+  return true;
 }
 
-void WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
                                           async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                           const char* end)
 {
@@ -153,9 +155,10 @@ void WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpReques
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(request, connection, begin,
                                                                                              end);
   }
+  return true;
 }
 
-void WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                                          async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                          const char* end)
 {
@@ -224,6 +227,7 @@ void WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
     connection->write("</li>");
   }
   connection->write("</ul></body></html>");
+  return true;
 }
 
 }

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -73,7 +73,6 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     ROS_ERROR("Exception when creating the web server! %s:%d", address_.c_str(), port_);
     throw;
   }
-
 }
 
 WebVideoServer::~WebVideoServer()

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -131,6 +131,28 @@ bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
   std::string type = request.get_query_param_value_or_default("type", __default_stream_type);
   if (stream_types_.find(type) != stream_types_.end())
   {
+    std::string topic = request.get_query_param_value_or_default("topic", "");
+    // Fallback for topics without corresponding compressed topics
+    if (type == std::string("ros_compressed"))
+    {
+      std::string compressed_topic_name = topic + "/compressed";
+      ros::master::V_TopicInfo topics;
+      ros::master::getTopics(topics);
+      bool did_find_compressed_topic = false;
+      for(ros::master::V_TopicInfo::iterator it = topics.begin(); it != topics.end(); ++it)
+      {
+        if (it->name == compressed_topic_name)
+        {
+          did_find_compressed_topic = true;
+          break;
+        }
+      }
+      if (!did_find_compressed_topic)
+      {
+        ROS_WARN_STREAM("Could not find compressed image topic for " << topic << ", falling back to mjpeg");
+        type = "mjpeg";
+      }
+    }
     boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection, nh_);
     streamer->start();
     boost::mutex::scoped_lock lock(subscriber_mutex_);
@@ -160,10 +182,32 @@ bool WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpReques
                                           async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                           const char* end)
 {
-  std::string type = request.get_query_param_value_or_default("type", "mjpeg");
+  std::string type = request.get_query_param_value_or_default("type", __default_stream_type);
   if (stream_types_.find(type) != stream_types_.end())
   {
     std::string topic = request.get_query_param_value_or_default("topic", "");
+    // Fallback for topics without corresponding compressed topics
+    if (type == std::string("ros_compressed"))
+    {
+      
+      std::string compressed_topic_name = topic + "/compressed";
+      ros::master::V_TopicInfo topics;
+      ros::master::getTopics(topics);
+      bool did_find_compressed_topic = false;
+      for(ros::master::V_TopicInfo::iterator it = topics.begin(); it != topics.end(); ++it)
+      {
+        if (it->name == compressed_topic_name)
+        {
+          did_find_compressed_topic = true;
+          break;
+        }
+      }
+      if (!did_find_compressed_topic)
+      {
+        ROS_WARN_STREAM("Could not find compressed image topic for " << topic << ", falling back to mjpeg");
+        type = "mjpeg";
+      }
+    }
 
     async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
         "Server", "web_video_server").header("Content-type", "text/html;").write(connection);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -44,7 +44,11 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
+#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+  cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+#else
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+#endif
 
   private_nh.param("port", port_, 8080);
   private_nh.param("verbose", __verbose, true);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -19,6 +19,8 @@ namespace web_video_server
 
 static bool __verbose;
 
+static std::string __default_stream_type;
+
 static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler forward,
                                   const async_web_server_cpp::HttpRequest &request,
                                   async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
@@ -60,6 +62,8 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("server_threads", server_threads, 1);
 
   private_nh.param("ros_threads", ros_threads_, 2);
+
+  private_nh.param<std::string>("default_stream_type", __default_stream_type, "mjpeg");
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
   stream_types_["png"] = boost::shared_ptr<ImageStreamerType>(new PngStreamerType());
@@ -124,7 +128,7 @@ bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
                                    async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                    const char* end)
 {
-  std::string type = request.get_query_param_value_or_default("type", "mjpeg");
+  std::string type = request.get_query_param_value_or_default("type", __default_stream_type);
   if (stream_types_.find(type) != stream_types_.end())
   {
     boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection, nh_);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -8,6 +8,7 @@
 #include "web_video_server/web_video_server.h"
 #include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
+#include "web_video_server/png_streamers.h"
 #include "web_video_server/vp8_streamer.h"
 #include "web_video_server/h264_streamer.h"
 #include "web_video_server/vp9_streamer.h"
@@ -61,6 +62,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
+  stream_types_["png"] = boost::shared_ptr<ImageStreamerType>(new PngStreamerType());
   stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
   stream_types_["h264"] = boost::shared_ptr<ImageStreamerType>(new H264StreamerType());

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -6,6 +6,7 @@
 #include <opencv2/opencv.hpp>
 
 #include "web_video_server/web_video_server.h"
+#include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
 #include "web_video_server/vp8_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
@@ -51,6 +52,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
+  stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
 
   handler_group_.addHandlerForPath("/", boost::bind(&WebVideoServer::handle_list_streams, this, _1, _2, _3, _4));

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -35,7 +35,7 @@ static void ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler
 }
 
 WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh) :
-    nh_(nh), image_transport_(nh), handler_group_(
+    nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
@@ -104,8 +104,7 @@ void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
   std::string type = request.get_query_param_value_or_default("type", "mjpeg");
   if (stream_types_.find(type) != stream_types_.end())
   {
-    boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection,
-                                                                                     image_transport_);
+    boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection, nh_);
     streamer->start();
     boost::mutex::scoped_lock lock(subscriber_mutex_);
     image_subscribers_.push_back(streamer);
@@ -121,7 +120,7 @@ void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &re
                                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                      const char* end)
 {
-  boost::shared_ptr<ImageStreamer> streamer(new JpegSnapshotStreamer(request, connection, image_transport_));
+  boost::shared_ptr<ImageStreamer> streamer(new JpegSnapshotStreamer(request, connection, nh_));
   streamer->start();
 
   boost::mutex::scoped_lock lock(subscriber_mutex_);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -42,7 +42,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
-  cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+  cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
 
   private_nh.param("port", port_, 8080);
   private_nh.param("verbose", __verbose, true);

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -97,8 +97,8 @@ void WebVideoServer::cleanup_inactive_streams()
   if (lock)
   {
     typedef std::vector<boost::shared_ptr<ImageStreamer> >::iterator itr_type;
-    itr_type new_end = std::remove_if(image_subscribers_.begin(), image_subscribers_.end(),
-                                      boost::bind(&ImageStreamer::isInactive, _1));
+    itr_type new_end = std::partition(image_subscribers_.begin(), image_subscribers_.end(),
+                                      !boost::bind(&ImageStreamer::isInactive, _1));
     if (__verbose)
     {
       for (itr_type itr = new_end; itr < image_subscribers_.end(); ++itr)

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -9,6 +9,8 @@
 #include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
 #include "web_video_server/vp8_streamer.h"
+#include "web_video_server/h264_streamer.h"
+#include "web_video_server/vp9_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
 
 namespace web_video_server
@@ -57,6 +59,8 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
   stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
+  stream_types_["h264"] = boost::shared_ptr<ImageStreamerType>(new H264StreamerType());
+  stream_types_["vp9"] = boost::shared_ptr<ImageStreamerType>(new Vp9StreamerType());
 
   handler_group_.addHandlerForPath("/", boost::bind(&WebVideoServer::handle_list_streams, this, _1, _2, _3, _4));
   handler_group_.addHandlerForPath("/stream", boost::bind(&WebVideoServer::handle_stream, this, _1, _2, _3, _4));

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -44,7 +44,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
-#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+#if ROS_HAS_STEADYTIMER || defined USE_STEADY_TIMER
   cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
 #else
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -61,10 +61,19 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
                                    boost::bind(&WebVideoServer::handle_stream_viewer, this, _1, _2, _3, _4));
   handler_group_.addHandlerForPath("/snapshot", boost::bind(&WebVideoServer::handle_snapshot, this, _1, _2, _3, _4));
 
-  server_.reset(
-      new async_web_server_cpp::HttpServer(address_, boost::lexical_cast<std::string>(port_),
-                                           boost::bind(ros_connection_logger, handler_group_, _1, _2, _3, _4),
-                                           server_threads));
+  try
+  {
+    server_.reset(
+        new async_web_server_cpp::HttpServer(address_, boost::lexical_cast<std::string>(port_),
+                                             boost::bind(ros_connection_logger, handler_group_, _1, _2, _3, _4),
+                                             server_threads));
+  }
+  catch(boost::exception& e)
+  {
+    ROS_ERROR("Exception when creating the web server! %s:%d", address_.c_str(), port_);
+    throw;
+  }
+
 }
 
 WebVideoServer::~WebVideoServer()


### PR DESCRIPTION
I needed https://github.com/RobotWebTools/web_video_server/pull/43 to compile with a newer version of libav/ffmpeg installed on my system, which will be the default starting from Ubuntu zesty. Instead of picking only this PR I merged the latest development branch from upstream and resolved the merge conflicts.

A new streamer type `RosCompressedStreamer` has been added in https://github.com/RobotWebTools/web_video_server/pull/16, which passes through compressed image data from ROS. I adapted the minimum rate publishing from the `ImageStreamer::restreamFrame(double max_age)` implementation.

Other patches also seem to be reasonable or even critical, e.g. https://github.com/RobotWebTools/web_video_server/pull/53.

This branch is completely untested. Carefully review if needed, or simply ignore.